### PR TITLE
feat: make illustration component memoized

### DIFF
--- a/src/components/illustration.tsx
+++ b/src/components/illustration.tsx
@@ -1,7 +1,7 @@
-import { lazy, Suspense } from "react";
+import { lazy, memo, Suspense } from "react";
 import { supabase } from "../supabase/supabase";
 
-export function Illustration({ file }: { file: string | null }) {
+export const Illustration = memo(({ file }: { file: string | null }) => {
 	const SupabaseImage = lazy(async () => {
 		const publicUrl = await getPublicUrl({ file });
 		return {
@@ -22,7 +22,7 @@ export function Illustration({ file }: { file: string | null }) {
 			<SupabaseImage />
 		</Suspense>
 	);
-}
+});
 
 async function getPublicUrl({ file }: { file: string | null }) {
 	if (!file) {


### PR DESCRIPTION
This is necessary so the component does not take too much time to rerender when dragging a postcard, making it look laggy. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207611809226915