### PR TITLE
feat: improve card positioning

### DIFF
--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -84,7 +84,7 @@ function toNode(idea: Idea): Node {
 function getRandomCircularCoordinates() {
 	// https://stackoverflow.com/questions/5837572/generate-a-random-point-within-a-circle-uniformly
 	const t = 2 * Math.PI * Math.random();
-	// r between 0.2 - 1 to too many cards in center
+	// r between 0.2 - 1 to avoid too many cards in center
 	const r = Math.max(0.2, Math.random());
 	const x = 0.5 + r * Math.cos(t) * 1000;
 	const y = 0.5 + r * Math.sin(t) * 850;


### PR DESCRIPTION
more cards are in the middle, but not too many should overlap in the very center.
- the canvas should be set to fitView() in the beginning to center the card pile on initialisation as part of #14 