### PR TITLE
feat: add custom events to zoom to new ideas/postcards 

### DIFF
--- a/src/components/hooks/use-listen-to-new-ideas.tsx
+++ b/src/components/hooks/use-listen-to-new-ideas.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useStoreApi } from "reactflow";
+
+export function useListenToNewIdeas({
+	postcardId,
+	nodeId,
+	zoomToCard,
+}: {
+	postcardId: string;
+	nodeId: string;
+	zoomToCard: () => void;
+}) {
+	const { addSelectedNodes } = useStoreApi().getState();
+
+	useEffect(() => {
+		const listener = (event: Event) => {
+			if ((event as CustomEvent).detail.id !== postcardId) {
+				return;
+			}
+
+			zoomToCard();
+			addSelectedNodes([nodeId]);
+		};
+
+		document.addEventListener("new-idea", listener);
+
+		return () => {
+			document.removeEventListener("new-idea", listener);
+		};
+	}, []);
+}

--- a/src/components/postcard.tsx
+++ b/src/components/postcard.tsx
@@ -8,6 +8,7 @@ import { useIsLoading } from "./hooks/use-is-loading.tsx";
 import { useSelectedNodes } from "./hooks/use-selected-nodes.tsx";
 import { useResetView } from "./hooks/use-reset-view.tsx";
 import { useZoomToCard } from "./hooks/use-zoom-to-card.tsx";
+import { useListenToNewIdeas } from "./hooks/use-listen-to-new-ideas.tsx";
 
 const angleVariations: { [key: string]: string } = {
 	IoT: "rotate-6",
@@ -25,6 +26,7 @@ export function Postcard({ data, id }: NodeProps<Idea>) {
 	const isCurrentPostcardSelected = useSelectedNodes(id);
 	const zoomToCard = useZoomToCard(id);
 	useResetView();
+	useListenToNewIdeas({ postcardId: data.id, zoomToCard, nodeId: id });
 
 	const onPostcardClick = () => {
 		setIsBackVisible(!isBackVisible);

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -21,7 +21,7 @@ export const dbStore = {
 				// @ts-ignore
 				"postgres_changes",
 				{
-					event: "*",
+					event: "insert",
 					schema: "public",
 					table: "ideas",
 				},
@@ -70,6 +70,11 @@ function updateNodes(data: { new: Idea }, renderCallback: () => void) {
 	nodes = [...nodes, toNode(newIdea)];
 
 	renderCallback();
+	setTimeout(
+		() =>
+			document.dispatchEvent(new CustomEvent("new-idea", { detail: newIdea })),
+		500,
+	);
 }
 
 function toNode(idea: Idea): Node {


### PR DESCRIPTION
 add custom events to zoom to new ideas/postcards after they are added to the page